### PR TITLE
Lionheart PNG output into subdirectory.

### DIFF
--- a/projects/lionheart/PngDisplay.cpp
+++ b/projects/lionheart/PngDisplay.cpp
@@ -34,7 +34,9 @@ void lionheart::PngDisplay::show(lionheart::SituationReport const& report, Blazo
   png_structp png_ptr = nullptr;
   png_infop info_ptr = nullptr;
   auto data = drawReport(report,p1,p2);
-  auto filename = output + "turn" + std::to_string(report.turns) + ".png";
+  char turn_number[5]; //= std::to_string(report.turns);
+  sprintf(turn_number,"%03d",report.turns);
+  auto filename = "./png/" + output + "turn" + turn_number + ".png";
   fp = fopen(filename.c_str(),"wb");
   png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING,nullptr,nullptr,nullptr);
   info_ptr = png_create_info_struct(png_ptr);

--- a/projects/lionheart/png/png_output_goes_here.txt
+++ b/projects/lionheart/png/png_output_goes_here.txt
@@ -1,0 +1,1 @@
+It really does.


### PR DESCRIPTION
This small change adds a directory named 'png' to the lionheart game and has the game output rendered png files into it.

png_output_goes_here.txt is only included because I couldn't figure out how to include an empty directory in a git repository.

I didn't do automatic directory creation using std::filesystem because I'm a lazy git. (Who has gcc 4.X and doesn't want to install gcc 6 right now.)